### PR TITLE
Update CSRF and validation for customers

### DIFF
--- a/app/Http/Controllers/API/UsersController.php
+++ b/app/Http/Controllers/API/UsersController.php
@@ -15,7 +15,7 @@ class UsersController extends BaseController
             $input = $request->all();
 
             $validator = Validator::make($input, [
-                'username' => 'required|unique:customers',
+                'username' => 'required|unique:customers,username',
                 'password' => 'required|min:8',
                 'c_password' => 'required|same:password', 
                 'fname' => 'required',
@@ -51,9 +51,9 @@ class UsersController extends BaseController
                 'fname' => $input['fname'],
                 'lname' => $input['lname'],
                 'contact_number' => $input['contact_number'],
-                'house_number' => $input['house_number'],
-                'street' => $input['street'],
-                'barangay' => $input['barangay'],
+                'house_number' => $input['house_number'] ?? '',
+                'street' => $input['street'] ?? '',
+                'barangay' => $input['barangay'] ?? '',
                 'municipality_city' => $input['municipality_city'],
                 'province' => $input['province'],
                 'postal_code' => $input['postal_code'],

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -14,5 +14,6 @@ class VerifyCsrfToken extends Middleware
     protected $except = [
         'api/login/customer',  
         'api/login/admin',
+        'api/customers',
     ];
 }

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -14,6 +14,5 @@ class VerifyCsrfToken extends Middleware
     protected $except = [
         'api/login/customer',  
         'api/login/admin',
-        'api/customers',
     ];
 }


### PR DESCRIPTION
- Added 'api/customers' to the CSRF token 
- Updated validation rules to require unique username for customers
- Added default values for house_number, street, and barangay fields if not provided